### PR TITLE
Thread keep alive feature

### DIFF
--- a/WatcherBot.FSharp/WatcherBot.FSharp.fsproj
+++ b/WatcherBot.FSharp/WatcherBot.FSharp.fsproj
@@ -12,8 +12,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Octokit" Version="0.50.0"/>
-        <PackageReference Update="FSharp.Core" Version="6.0.3"/>
+        <PackageReference Include="Octokit" Version="5.0.0"/>
+        <PackageReference Update="FSharp.Core" Version="7.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/WatcherBot/Commands/Admin.cs
+++ b/WatcherBot/Commands/Admin.cs
@@ -5,6 +5,7 @@ using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using WatcherBot.Utils;
 
 namespace WatcherBot.Commands;
@@ -18,24 +19,26 @@ public class AdminCommandModule : BaseCommandModule
     [RequireDmOrOutputGuild]
     public async Task WhoIs(CommandContext context, [Description("The member to look up")] DiscordMember member)
     {
-        DiscordEmbedBuilder embed = new DiscordEmbedBuilder().WithColor(member.Color)
-                                                             .WithAuthor(member.UsernameWithDiscriminator,
-                                                                         iconUrl: member.AvatarUrl)
-                                                             .WithThumbnail(member.GuildAvatarUrl)
-                                                             .WithTimestamp(DateTimeOffset.Now)
-                                                             .WithFooter($"ID: {member.Id}")
-                                                             .WithDescription(member.Mention)
-                                                             .AddField("Joined",
-                                                                       Formatter.Timestamp(member.JoinedAt,
-                                                                           TimestampFormat.ShortDateTime),
-                                                                       true)
-                                                             .AddField("Created",
-                                                                       Formatter.Timestamp(member.CreationTimestamp,
-                                                                           TimestampFormat.ShortDateTime),
-                                                                       true);
+        DiscordEmbedBuilder embed =
+            new DiscordEmbedBuilder().WithColor(member.Color)
+                                     .WithAuthor(member.UsernameWithDiscriminator,
+                                                 iconUrl: member.AvatarUrl)
+                                     .WithThumbnail(member.GuildAvatarUrl)
+                                     .WithTimestamp(DateTimeOffset.Now)
+                                     .WithFooter($"ID: {member.Id}")
+                                     .WithDescription(member.Mention)
+                                     .AddField(new DiscordEmbedField("Joined",
+                                                                     Formatter.Timestamp(member.JoinedAt,
+                                                                         TimestampFormat.ShortDateTime),
+                                                                     true))
+                                     .AddField(new DiscordEmbedField("Created",
+                                                                     Formatter.Timestamp(member.CreationTimestamp,
+                                                                         TimestampFormat.ShortDateTime),
+                                                                     true));
         if (member.Roles.Any())
         {
-            embed.AddField($"Roles ({member.Roles.Count()})", string.Join(", ", member.Roles.Select(r => r.Name)));
+            embed.AddField(new DiscordEmbedField($"Roles ({member.Roles.Count})",
+                                                 string.Join(", ", member.Roles.Select(r => r.Name))));
         }
 
         await context.RespondAsync(embed.Build());
@@ -53,10 +56,10 @@ public class AdminCommandModule : BaseCommandModule
                                     .WithTimestamp(DateTimeOffset.Now)
                                     .WithFooter(user.Id.ToString())
                                     .WithDescription($"{user.Mention}\nNot in server")
-                                    .AddField("Created",
-                                              Formatter.Timestamp(user.CreationTimestamp,
-                                                                  TimestampFormat.ShortDateTime),
-                                              true);
+                                    .AddField(new DiscordEmbedField("Created",
+                                                                    Formatter.Timestamp(user.CreationTimestamp,
+                                                                        TimestampFormat.ShortDateTime),
+                                                                    true));
 
         await context.RespondAsync(embed.Build());
     }

--- a/WatcherBot/Commands/Ban.cs
+++ b/WatcherBot/Commands/Ban.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
-using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WatcherBot.Utils;

--- a/WatcherBot/Commands/KillSwitch.cs
+++ b/WatcherBot/Commands/KillSwitch.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
-using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using Microsoft.Extensions.Logging;
 using WatcherBot.Utils;
 

--- a/WatcherBot/Commands/Purge.cs
+++ b/WatcherBot/Commands/Purge.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using WatcherBot.Utils;
 
 namespace WatcherBot.Commands;
@@ -17,8 +17,9 @@ public class PurgeCommandModule : BaseCommandModule
                  + " in a direction indicated by sign (negative => up, positive => down).")]
     [RequirePermissionInGuild(Permissions.ManageMessages)]
     [RequireModeratorRoleInGuild]
-    public async Task Purge(CommandContext context, DiscordMessage msg, int count = 1024, [RemainingText] string? reason = null) {
-
+    public async Task Purge(CommandContext          context, DiscordMessage msg, int count = 1024,
+                            [RemainingText] string? reason = null)
+    {
         Func<ulong, int, Task<IReadOnlyList<DiscordMessage>>> getMessages =
             count < 0 ? msg.Channel.GetMessagesBeforeAsync : msg.Channel.GetMessagesAfterAsync;
 

--- a/WatcherBot/Commands/Timeout.cs
+++ b/WatcherBot/Commands/Timeout.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading.Tasks;
-using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using Microsoft.Extensions.Options;
 using WatcherBot.Utils;
 

--- a/WatcherBot/Config/Config.cs
+++ b/WatcherBot/Config/Config.cs
@@ -9,7 +9,7 @@ namespace WatcherBot.Config;
 public class Config
 {
     public const string ConfigSection = "Watcher";
-    private readonly Lazy<Dictionary<ulong, Range>> attachmentLimitsLazy;
+    private readonly System.Lazy<Dictionary<ulong, Range>> attachmentLimitsLazy;
 
     public Config()
     {
@@ -25,7 +25,7 @@ public class Config
     private HashSet<ulong> moderatorRoleIds { get; } = new();
     public IReadOnlySet<ulong> ModeratorRoleIds => moderatorRoleIds;
 
-    private string formattingCharacters { get; init; } = "";
+    private string formattingCharacters { get; } = "";
     public IReadOnlySet<char> FormattingCharacters => formattingCharacters.ToHashSet();
 
     private HashSet<ulong> prohibitCommandsFromUsers { get; } = new();
@@ -40,6 +40,7 @@ public class Config
     private HashSet<ulong> cringeChannels { get; } = new();
     public IReadOnlySet<ulong> CringeChannels => cringeChannels;
 
+    // ReSharper disable once CollectionNeverUpdated.Local
     private Dictionary<string, Range> attachmentLimits { get; } = new();
     public IReadOnlyDictionary<ulong, Range> AttachmentLimits => attachmentLimitsLazy.Value;
 
@@ -62,6 +63,11 @@ public class Config
 
     public ulong SpamFilterExemptionRole { get; init; }
     public ulong SpamReportChannel { get; init; }
+
+    private HashSet<ulong> keepAliveThreadIds { get; } = new();
+    public IReadOnlySet<ulong> KeepAliveThreadIds => keepAliveThreadIds;
+
+    public string KeepAliveMessage { get; init; } = "";
 
     public string YeensayMaskPath { get; init; } = "";
 }

--- a/WatcherBot/Config/Config.cs
+++ b/WatcherBot/Config/Config.cs
@@ -9,7 +9,7 @@ namespace WatcherBot.Config;
 public class Config
 {
     public const string ConfigSection = "Watcher";
-    private readonly System.Lazy<Dictionary<ulong, Range>> attachmentLimitsLazy;
+    private readonly Lazy<Dictionary<ulong, Range>> attachmentLimitsLazy;
 
     public Config()
     {

--- a/WatcherBot/Models/WatcherDatabaseContext.cs
+++ b/WatcherBot/Models/WatcherDatabaseContext.cs
@@ -10,11 +10,14 @@ public class WatcherDatabaseContext : DbContext
 {
     private static readonly Lazy<string> ConnectionString = new(() =>
     {
-        var                    configBuilder             = new ConfigurationBuilder();
-        IConfigurationBuilder? jsonFile                  = configBuilder.AddJsonFile("appsettings.json");
-        IConfigurationRoot?    build                     = jsonFile.Build();
-        string?                connString                = build.GetConnectionString("WatcherDatabase");
-        string                 executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
+        var                   configBuilder          = new ConfigurationBuilder();
+        IConfigurationBuilder jsonFile               = configBuilder.AddJsonFile("appsettings.json");
+        IConfigurationRoot    build                  = jsonFile.Build();
+        const string          watcherDatabaseSection = "WatcherDatabase";
+        string connString = build.GetConnectionString(watcherDatabaseSection)
+                            ?? throw new
+                                InvalidOperationException($"Missing connection string {watcherDatabaseSection}");
+        string executingAssemblyLocation = Assembly.GetExecutingAssembly().Location;
         return connString.Replace("$WD", Path.GetDirectoryName(executingAssemblyLocation));
     });
 

--- a/WatcherBot/Utils/ANSI/ForegroundColour.cs
+++ b/WatcherBot/Utils/ANSI/ForegroundColour.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace WatcherBot.Utils.ANSI;
 
 public enum ForegroundColour

--- a/WatcherBot/Utils/ANSI/Style.cs
+++ b/WatcherBot/Utils/ANSI/Style.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace WatcherBot.Utils.ANSI;
 
 public enum Style

--- a/WatcherBot/Utils/BarotraumaToolBox.cs
+++ b/WatcherBot/Utils/BarotraumaToolBox.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 using Octokit;
 
 namespace WatcherBot.Utils;
@@ -34,19 +35,26 @@ public static class BarotraumaToolBox
         }
     }
 
-    public static Task[] ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> action) => source.Select(action).ToArray();
+    public static Task[] ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> action) =>
+        source.Select(action).ToArray();
 
     public static MemoryStream ToMemoryStream(this string content)
     {
-        byte[]   bytes = Encoding.UTF8.GetBytes(content);
+        byte[] bytes = Encoding.UTF8.GetBytes(content);
         return new MemoryStream(bytes);
     }
 
     private static async Task<DiscordDmChannel?> GetDmChannelAsync(this CommandContext context)
     {
-        if (context.Channel is DiscordDmChannel dmChannel) { return dmChannel; }
+        if (context.Channel is DiscordDmChannel dmChannel)
+        {
+            return dmChannel;
+        }
 
-        if (context.Member is not null) { return await context.Member.CreateDmChannelAsync(); }
+        if (context.Member is not null)
+        {
+            return await context.Member.CreateDmChannelAsync();
+        }
 
         return null;
     }
@@ -54,31 +62,46 @@ public static class BarotraumaToolBox
     public static async Task RespondDmAsync(this CommandContext context, Action<DiscordMessageBuilder> action)
     {
         DiscordDmChannel? dmChannel = await context.GetDmChannelAsync();
-        if (dmChannel is not null) { await dmChannel.SendMessageAsync(action); }
+        if (dmChannel is not null)
+        {
+            await dmChannel.SendMessageAsync(action);
+        }
     }
 
     public static async Task RespondDmAsync(this CommandContext context, DiscordEmbed embed)
     {
         DiscordDmChannel? dmChannel = await context.GetDmChannelAsync();
-        if (dmChannel is not null) { await dmChannel.SendMessageAsync(embed); }
+        if (dmChannel is not null)
+        {
+            await dmChannel.SendMessageAsync(embed);
+        }
     }
 
     public static async Task RespondDmAsync(this CommandContext context, DiscordMessageBuilder builder)
     {
         DiscordDmChannel? dmChannel = await context.GetDmChannelAsync();
-        if (dmChannel is not null) { await dmChannel.SendMessageAsync(builder); }
+        if (dmChannel is not null)
+        {
+            await dmChannel.SendMessageAsync(builder);
+        }
     }
 
     public static async Task RespondDmAsync(this CommandContext context, string content)
     {
         DiscordDmChannel? dmChannel = await context.GetDmChannelAsync();
-        if (dmChannel is not null) { await dmChannel.SendMessageAsync(content); }
+        if (dmChannel is not null)
+        {
+            await dmChannel.SendMessageAsync(content);
+        }
     }
 
     public static async Task RespondDmAsync(this CommandContext context, string content, DiscordEmbed embed)
     {
         DiscordDmChannel? dmChannel = await context.GetDmChannelAsync();
-        if (dmChannel is not null) { await dmChannel.SendMessageAsync(content, embed); }
+        if (dmChannel is not null)
+        {
+            await dmChannel.SendMessageAsync(content, embed);
+        }
     }
 
     public static int CountSubstrings(this string str, string substr)
@@ -88,7 +111,10 @@ public static class BarotraumaToolBox
         while (true)
         {
             index = str.IndexOf(substr, index, StringComparison.OrdinalIgnoreCase);
-            if (index < 0) { break; }
+            if (index < 0)
+            {
+                break;
+            }
 
             index++;
             count++;
@@ -117,7 +143,10 @@ public static class BarotraumaToolBox
                                           + $"```\n{spamMessage.Content.Replace("`", "")}\n```\n\n"
                                           + "This is a spam prevention measure. If this was a false positive, please contact a moderator or administrator.");
         }
-        catch (Exception e) { dmException = e; }
+        catch (Exception e)
+        {
+            dmException = e;
+        }
 
         if (!spamMessage.Channel.IsPrivate)
         {
@@ -135,4 +164,13 @@ public static class BarotraumaToolBox
                                              : ""));
         }
     }
+
+    public static TimeSpan ToTimeSpan(this ThreadAutoArchiveDuration duration) => duration switch
+    {
+        ThreadAutoArchiveDuration.OneHour   => TimeSpan.FromHours(1),
+        ThreadAutoArchiveDuration.OneDay    => TimeSpan.FromDays(1),
+        ThreadAutoArchiveDuration.ThreeDays => TimeSpan.FromDays(3),
+        ThreadAutoArchiveDuration.OneWeek   => TimeSpan.FromDays(7),
+        _                                   => throw new ArgumentOutOfRangeException(nameof(duration), duration, null),
+    };
 }

--- a/WatcherBot/Utils/BarotraumaToolBox.cs
+++ b/WatcherBot/Utils/BarotraumaToolBox.cs
@@ -165,12 +165,5 @@ public static class BarotraumaToolBox
         }
     }
 
-    public static TimeSpan ToTimeSpan(this ThreadAutoArchiveDuration duration) => duration switch
-    {
-        ThreadAutoArchiveDuration.OneHour   => TimeSpan.FromHours(1),
-        ThreadAutoArchiveDuration.OneDay    => TimeSpan.FromDays(1),
-        ThreadAutoArchiveDuration.ThreeDays => TimeSpan.FromDays(3),
-        ThreadAutoArchiveDuration.OneWeek   => TimeSpan.FromDays(7),
-        _                                   => throw new ArgumentOutOfRangeException(nameof(duration), duration, null),
-    };
+    public static TimeSpan ToTimeSpan(this ThreadAutoArchiveDuration duration) => TimeSpan.FromMinutes((int)duration);
 }

--- a/WatcherBot/Utils/DateTimeConverter.cs
+++ b/WatcherBot/Utils/DateTimeConverter.cs
@@ -14,7 +14,7 @@ public class DateTimeConverter : IArgumentConverter<DateTime>
         Match match = await Task.Run(() => Regex.Match(value.ToLower(), @"^(\d+)([a-z]+)$"));
         if (!match.Success || !int.TryParse(match.Groups[1].ValueSpan, out int count))
         {
-            return Optional.FromNoValue<DateTime>();
+            return Optional.None;
         }
 
         DateTime ret;
@@ -47,9 +47,9 @@ public class DateTimeConverter : IArgumentConverter<DateTime>
                 ret = DateTime.Now.AddYears(count);
                 break;
             default:
-                return Optional.FromNoValue<DateTime>();
+                return Optional.None;
         }
 
-        return Optional.FromValue(ret);
+        return Optional.Some(ret);
     }
 }

--- a/WatcherBot/Utils/Homoglyphs.cs
+++ b/WatcherBot/Utils/Homoglyphs.cs
@@ -9,6 +9,7 @@ public static class Homoglyphs
 {
     ///List of homoglyphs taken from https://github.com/codebox/homoglyph/
     // @formatter:off
+    // ReSharper disable once InconsistentNaming
     private static readonly ImmutableHashSet<ImmutableHashSet<uint>> homoglyphs = new [] {
         new uint[]{0x20,0xa0,0x1680,0x2000,0x2001,0x2002,0x2003,0x2004,0x2005,0x2006,0x2007,0x2008,0x2009,0x200a,0x2028,0x2029,0x202f,0x205f},
         new uint[]{0x21,0x1c3,0x2d51,0xff01},

--- a/WatcherBot/Utils/LevenshteinDistance.cs
+++ b/WatcherBot/Utils/LevenshteinDistance.cs
@@ -48,6 +48,7 @@ public static class LevenshteinDistance
 
     public static (int Index, int Length, int Distance)? FindSubstr(string str, string substr, int maxDistance)
     {
+        // ReSharper disable once PatternAlwaysMatches
         if (str.IndexOf(substr, StringComparison.Ordinal) is int val and > 0)
         {
             return (val, substr.Length, 0);
@@ -63,7 +64,7 @@ public static class LevenshteinDistance
         {
             ReadOnlySpan<char> subStrToTest = str.AsSpan(j, testLength);
             int                distance     = Calculate(subStrToTest, substr);
-            if (distance > maxDistance || foundDistance >= 0 && distance >= foundDistance)
+            if (distance > maxDistance || (foundDistance >= 0 && distance >= foundDistance))
             {
                 continue;
             }

--- a/WatcherBot/Utils/RequirePermissionInGuild.cs
+++ b/WatcherBot/Utils/RequirePermissionInGuild.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Threading.Tasks;
-using DisCatSharp;
 using DisCatSharp.CommandsNext;
 using DisCatSharp.CommandsNext.Attributes;
 using DisCatSharp.Entities;
+using DisCatSharp.Enums;
 
 namespace WatcherBot.Utils;
 

--- a/WatcherBot/Utils/Templates.cs
+++ b/WatcherBot/Utils/Templates.cs
@@ -14,9 +14,6 @@ public class Templates
         timeoutLazy = new Lazy<string>(() => string.Join('\n', timeout));
     }
 
-    private List<string> ban { get; } = new();
-    private List<string> timeout { get; } = new();
-
     public string Ban => banLazy.Value;
     public string Timeout => timeoutLazy.Value;
     public string DefaultAppealRecipient { get; init; } = "";
@@ -25,4 +22,10 @@ public class Templates
         anon == Anonymous.Yes || otherName == DefaultAppealRecipient
             ? DefaultAppealRecipient
             : $"{otherName} or {DefaultAppealRecipient}";
+
+    // ReSharper disable CollectionNeverUpdated.Local
+    private List<string> ban { get; } = new();
+
+    private List<string> timeout { get; } = new();
+    // ReSharper restore CollectionNeverUpdated.Local
 }

--- a/WatcherBot/Utils/ThreadKeepAlive.cs
+++ b/WatcherBot/Utils/ThreadKeepAlive.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using DisCatSharp;
+using DisCatSharp.Entities;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace WatcherBot.Utils;
+
+public class ThreadKeepAlive : LoopingTask
+{
+    private readonly DiscordClient client;
+    private readonly string keepAliveMessage;
+    private readonly IReadOnlySet<ulong> keepAliveThreadIds;
+
+    public ThreadKeepAlive(BotMain botMain, IOptions<Config.Config> config) : base(botMain, config)
+    {
+        client             = botMain.Client;
+        keepAliveThreadIds = config.Value.KeepAliveThreadIds;
+        keepAliveMessage   = config.Value.KeepAliveMessage;
+    }
+
+    protected override TimeSpan LoopFrequency => TimeSpan.FromSeconds(30);
+
+    protected override Task LoopWork() => Task.WhenAll(keepAliveThreadIds.Select(CheckThread));
+
+    private async Task CheckThread(ulong id)
+    {
+        Logger.LogInformation("Checking thread {ThreadId} for archival prevention", id);
+        DiscordThreadChannel thread = await client.GetThreadAsync(id, true);
+
+        if (thread.ThreadMetadata.Locked == true)
+        {
+            Logger.LogInformation("Thread {ThreadId} is locked", id);
+            return;
+        }
+
+        if (thread.ThreadMetadata.Archived)
+        {
+            Logger.LogInformation("Unarchiving thread {ThreadId}", id);
+            await thread.UnarchiveAsync();
+            return;
+        }
+
+        if (!thread.LastMessageId.HasValue)
+        {
+            Logger.LogInformation("Cannot find last message for thread {ThreadId}", id);
+            return;
+        }
+
+        DiscordMessage lastMessage = await thread.GetMessageAsync(thread.LastMessageId.Value);
+
+        Logger.LogDebug("Last message contents is {LastMessage}", lastMessage.Content);
+
+        bool willArchive = DateTimeOffset.Now + LoopFrequency - lastMessage.Timestamp
+                           >= thread.ThreadMetadata.AutoArchiveDuration.ToTimeSpan();
+
+        if (!willArchive)
+        {
+            Logger.LogInformation("Thread {ThreadId} will not be archived before next check", id);
+            return;
+        }
+
+        Logger.LogInformation("Sending keep alive message for thread {ThreadId}", id);
+
+        await thread.SendMessageAsync(keepAliveMessage);
+    }
+}

--- a/WatcherBot/WatcherBot.csproj
+++ b/WatcherBot/WatcherBot.csproj
@@ -16,41 +16,41 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="DisCatSharp" Version="10.0.0-nightly-00319" />
-        <PackageReference Include="DisCatSharp.CommandsNext" Version="10.0.0-nightly-00319" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.3">
+        <PackageReference Include="DisCatSharp" Version="10.3.2"/>
+        <PackageReference Include="DisCatSharp.CommandsNext" Version="10.3.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.3" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.3" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
-        <PackageReference Include="Octokit" Version="0.50.0" />
-        <PackageReference Include="Serilog" Version="2.10.0" />
-        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-        <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-        <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
-        <PackageReference Include="System.Configuration.Abstractions" Version="2.0.2.45" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0"/>
+        <PackageReference Include="Octokit" Version="5.0.0"/>
+        <PackageReference Include="Serilog" Version="2.12.0"/>
+        <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="3.4.0"/>
+        <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="5.0.0"/>
+        <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3"/>
+        <PackageReference Include="System.Configuration.Abstractions" Version="2.0.2.45"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\WatcherBot.FSharp\WatcherBot.FSharp.fsproj" />
+        <ProjectReference Include="..\WatcherBot.FSharp\WatcherBot.FSharp.fsproj"/>
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Logs" />
-        <Folder Include="Migrations" />
+        <Folder Include="Logs"/>
+        <Folder Include="Migrations"/>
     </ItemGroup>
 
     <ItemGroup>
-        <None Remove="appsettings.json" />
+        <None Remove="appsettings.json"/>
         <Content Include="appsettings.json">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </Content>

--- a/WatcherBot/appsettings.example.json
+++ b/WatcherBot/appsettings.example.json
@@ -99,6 +99,10 @@
         "Networking": "Cyan"
       }
     },
+    "KeepAliveThreadIds": [
+      0
+    ],
+    "KeepAliveMessage": "Ah, ha, ha, ha, stayin' alive, stayin' alive",
     "YeensayMaskPath": ""
   },
   "ConnectionStrings": {


### PR DESCRIPTION
Adds a feature to the Watcher that allows it to keep a thread alive indefinitely. This is done by checking whether the thread is already archived and unarchiving it, or sending a message in the channel to keep it alive.

This change adds two new config fields, specifying the IDs of which threads to preserve and a message to send.

https://github.com/Jlobblet/WatcherBot/blob/532002ac59a1d88ae98992eabaf8de88630ee5b4/WatcherBot/appsettings.example.json#L102-L105

In addition, this change bumps the versions of most packages and cleans up some depcreciated code and warnings. The bumps were necessary because features in later DisCatSharp releases were required, specifically the ability to always fetch a thread from the API rather than relying on the cache. This is required to track the most recent message in the thread reliably.